### PR TITLE
Also exclude straight http aws.amazon.com URLs.

### DIFF
--- a/KeepOnSmiling.safariextension/Info.plist
+++ b/KeepOnSmiling.safariextension/Info.plist
@@ -25,6 +25,8 @@
 		<array>
 			<string>https://*.aws.amazon.com/*</string>
 			<string>https://aws.amazon.com/*</string>
+			<string>http://*.aws.amazon.com/*</string>
+			<string>http://aws.amazon.com/*</string>
 		</array>
 		<key>Scripts</key>
 		<dict>


### PR DESCRIPTION
aws.amazon.com is also served via http, and there are many links that use the non-secure scheme.  As such I blacklisted the straight http URL patterns as well, so that those links won't be redirected over to smile.