### PR TITLE
Add Seller Central to Blacklist

### DIFF
--- a/KeepOnSmiling.safariextension/Info.plist
+++ b/KeepOnSmiling.safariextension/Info.plist
@@ -27,6 +27,8 @@
 			<string>https://aws.amazon.com/*</string>
 			<string>http://*.aws.amazon.com/*</string>
 			<string>http://aws.amazon.com/*</string>
+			<string>http://sellercentral.amazon.com/*</string>
+			<string>https://sellercentral.amazon.com/*</string>
 			<string>https://www.amazon.com/gp/wishlist/*</string>
 			<string>http://www.amazon.com/gp/wishlist/*</string>
 			<string>https://www.amazon.de/gp/wishlist/*</string>


### PR DESCRIPTION
The Seller Central dashboard is where you go to manage inventory and list items for sale. It should not redirect to `smile.amazon.com`.